### PR TITLE
学内サーバーのIPアドレスをALLOWED_HOSTSに追加

### DIFF
--- a/pbl_project/settings.py
+++ b/pbl_project/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'django-insecure-wjso^p!ll^w%b$!56r)vy5c+m3dd7v74z*l=^nv8edbq9nz#a_
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS =['localhost', '127.0.0.1'] + [f'133.15.185.{i}' for i in range(8, 255)] # 学内サーバーIPアドレスとlocalhostを許可
 
 
 # Application definition


### PR DESCRIPTION
## 概要
学内サーバーでのデプロイに対応するため、`ALLOWED_HOSTS`に学内サーバーのIPアドレス範囲を追加しました。

## 変更内容
- `pbl_project/settings.py`の`ALLOWED_HOSTS`設定を更新
  - `localhost`と`127.0.0.1`を追加（開発環境用）
  - `133.15.185.8`～`133.15.185.254`のIPアドレス範囲を追加（学内サーバー用）

## 変更理由
学内サーバー（VM）にデプロイする際、DjangoのALLOWED_HOSTS設定が空のままだとアクセスが拒否されるため、学内サーバーのIPアドレス範囲を許可リストに追加する必要がありました。

## テスト方法
- [x] ローカル環境で`python manage.py runserver`が正常に動作することを確認
- [x] 学内サーバーにデプロイ後、外部からアクセスできることを確認

## 関連Issue
なし