### PR TITLE
開発環境へのデプロイ手順へ修正

### DIFF
--- a/docs/HOW_TO_DEPLOY.md
+++ b/docs/HOW_TO_DEPLOY.md
@@ -52,8 +52,9 @@ git checkout <チームのブランチ名>
 例: `git checkout team_terrace`
 
 #### 3-3. 依存ライブラリのインストール
-[uvインストールガイド](https://github.com/mikawa-pbl/pbl-app-2025/blob/docs/how_to_deploy_dev_VMs/docs/UV_INSTALLATION.md#linux)を参考にしてuvのインストールを行ってください
+1. [uvインストールガイド](https://github.com/mikawa-pbl/pbl-app-2025/blob/docs/how_to_deploy_dev_VMs/docs/UV_INSTALLATION.md#linux)を参考にしてuvのインストールを行ってください（※インストールはVM上で最初の1回だけで構いません。以降は `uv sync` のみでOKです）。
 
+2. 以下のコマンドを実行して依存関係を同期します。
 ```bash
 uv sync
 ```


### PR DESCRIPTION
## 概要
開発環境用のデプロイ手順書を作成しました。本番環境用の手順書を開発環境向けに修正し、初回セットアップ手順の追加、マイグレーションによるデータ投入方式への対応、およびセキュリティ面での改善を行いました。


## 変更内容
### 1. タイトルと前提条件の変更
- タイトルを「デプロイ手順書（本番環境）」→「デプロイ手順書（開発環境）」に変更
- 前提条件を開発環境向けに修正
  - 「アプリケーションのソースコードはすでにVMにクローン済み」を削除
  - 「初期段階のアプリケーションが実行されている状態（mainブランチ）」を削除
  - 「各チームの作業用ブランチが作成済み」を追加

### 2. 初回セットアップ手順の追加（手順3）
開発環境では初期状態からセットアップが必要なため、以下の手順を追加:
- GitHubからのソースコードクローン
- チームの作業用ブランチへの切り替え
- 依存ライブラリのインストール（`uv sync`）
- データベースマイグレーションの実行

**注意**: 初回セットアップ後、手順5-6で`uv sync`とマイグレーションを再度実行することになりますが、冪等性があるため問題ありません。

### 3. ブランチ取得手順の修正（手順4）
- mainブランチ → 各チームの作業用ブランチに変更
- 例: `git checkout team_terrace` → `git pull origin team_terrace`

### 4. マイグレーション手順の説明更新（手順6）
- PR #40 で導入されたマイグレーションによるデータ投入方式に対応
- マイグレーション実行により初期データも自動投入される旨を明記
- [データの追加をmigration管理する手順書](HOW_TO_DATA_INSERT_BY_MIGRATION.md)へのリンクを追加

### 5. データ投入セクションの削除（旧手順6）
- `dbshell`を使った手動データ投入手順を削除
- マイグレーション方式に統一（PR #40 の方針に従う）

### 6. アプリケーション起動のセキュリティ改善（手順7）
- Djangoをrootユーザーではなく一般ユーザーで実行するように変更
- `setcap`を使用して80番ポートを一般ユーザーで利用可能にする手順を追加（手順7-0）
- `start-stop-daemon`に`--chuid`オプションを追加し、一般ユーザー権限で起動
- セキュリティリスクの軽減とベストプラクティスへの準拠

### 7. アプリケーション再起動の注記追加
- 初回セットアップ時は停止コマンドが不要である旨の注記を追加

## 工夫したポイント
1. **初回と2回目以降の手順を明確に分離**: 初回セットアップ（手順3）と2回目以降（手順4）を明確に区別し、どちらの場合でも迷わず実行できるようにしました

2. **具体例の充実**: `<チーム名>`などのプレースホルダーに加えて、`team_terrace`を使った具体例を各所に追加し、理解しやすくしました

3. **マイグレーション方式への移行を明示**: PR #40 で導入された新しいデータ投入方式について、関連ドキュメントへのリンクとともに説明を追加しました

4. **セキュリティベストプラクティスの適用**: rootユーザーでアプリケーションを実行するリスクを避け、`setcap`による権限付与で最小権限の原則を実現しました

5. **注意事項の適切な配置**: 初回セットアップ時や再起動時の注意事項を、該当する手順の直前に配置し、見落としを防ぎました

## レビューしてほしいポイント
1. **開発環境特有の注意事項**: 開発環境でのデプロイにおいて、他に注意すべき点や追加すべき手順がないか確認をお願いします

2. **PR #40 との整合性**: マイグレーションによるデータ投入方式の説明が、PR #40 の内容と整合しているか確認をお願いします

3. **セキュリティ設定の妥当性**: `setcap`を使用した権限付与の方法が開発環境として適切か、またVM環境での動作に問題がないか確認をお願いします

## 関連PR
- Related to #40 (データの追加をmigration管理する方法のドキュメント追加)