### PR TITLE
team_terrace: スレッド返信をtextarea化（改行/送信キー対応）

### DIFF
--- a/team_terrace/static/team_terrace/css/room.css
+++ b/team_terrace/static/team_terrace/css/room.css
@@ -861,6 +861,8 @@ body {
   font-size: 0.9rem;
   line-height: 1.5;
   animation: replyAppear 0.3s ease-out backwards;
+  /* Preserve newlines in thread replies */
+  white-space: pre-wrap;
 }
 
 @keyframes replyAppear {
@@ -886,6 +888,15 @@ body {
   font-size: 0.9rem;
   outline: none;
   transition: var(--transition-smooth);
+
+  /* textarea tweaks */
+  resize: none;
+  line-height: 1.4;
+  min-height: 44px;
+  max-height: 140px;
+  overflow-y: hidden;
+  box-sizing: border-box;
+  white-space: pre-wrap;
 }
 
 #reply-input:focus {

--- a/templates/teams/team_terrace/room.html
+++ b/templates/teams/team_terrace/room.html
@@ -89,7 +89,7 @@
             <h2>スレッド</h2>
             <div id="thread-messages"></div>
             <div class="thread-input-area">
-                <input type="text" id="reply-input" placeholder="返信を入力..." autocomplete="off">
+                <textarea id="reply-input" placeholder="返信を入力..." autocomplete="off" rows="1"></textarea>
                 <button onclick="sendReply()" type="button">返信</button>
             </div>
         </div>


### PR DESCRIPTION
## 概要 / 目的
team_terrace のスレッド返信（Thread Modal）の入力欄を `textarea` 化し、本体チャットと同じ感覚で
- 改行入力
- 長文時のauto-resize / スクロール
- PCでの送信キー（Enter / Ctrl+Enter）挙動
を扱えるようにします。あわせて返信表示側でも改行が反映されるようにします。

## 変更内容
- Thread Modal の返信入力 `#reply-input` を `input` → `textarea` に変更（`rows="1"`）
- 返信 textarea に auto-resize を追加
  - 最大 `140px` まで伸長
  - 超過時のみ内部スクロール（通常はスクロールバー非表示）
  - モーダル初期非表示時に高さが潰れるのを避けるため、モーダル表示後に autoresize を実行
  - `min-height: 44px` を追加して見た目の潰れを防止
- PC幅（min-width: 768px）では、本体の送信モードに追従して送信キー挙動を統一
  - Enter送信モード：`Enter` で送信 / `Shift+Enter` で改行
  - Ctrl+Enter送信モード：`Ctrl+Enter`（または `Cmd+Enter`）で送信
- 返信表示（`.reply`）に `white-space: pre-wrap` を付与し、改行を表示欄に反映

## 動作確認
- PC幅(1440)
  - スレッドモーダルを開いたとき返信 textarea が潰れない（min-height/auto-resize）
  - 複数行入力で auto-resize し、max-height 到達時のみ内部スクロールに切り替わる
  - Ctrl+Enter送信モードで `Ctrl+Enter` 送信できる
  - Enter送信モードで `Shift+Enter` 改行 / `Enter` 送信できる
  - 送信後に入力欄が空になり、高さもリセットされる
  - 返信表示欄で改行が維持される（pre-wrap）
- モバイル幅(390)
  - Enterは改行、返信ボタンで送信できる（従来通り）

## 補足
- 本体側（チャット入力欄/送信モード切替）の仕様に追従する形でスレッド返信も整備しました。